### PR TITLE
Theme/darkmint

### DIFF
--- a/components/common/ServerBar.tsx
+++ b/components/common/ServerBar.tsx
@@ -88,7 +88,7 @@ function ServerBar() {
             })}
             <div
                 onClick={addServer}
-                className="bg-blue-400 h-[3.5rem] w-[3.5rem] rounded-full hover:rounded-xl cursor-pointer mx-auto flex items-center justify-center font-semibold text-xl"
+                className="bg-fabchat-addServerBtn h-[3.5rem] w-[3.5rem] rounded-full hover:rounded-xl cursor-pointer mx-auto flex items-center justify-center font-semibold text-xl"
             >
                 +
             </div>

--- a/components/common/UserBar.tsx
+++ b/components/common/UserBar.tsx
@@ -19,7 +19,7 @@ function UserBar() {
                     <p className="font-bold text-white truncate">
                         {user?.displayName as string}
                     </p>
-                    <p>Online</p>
+                    <p className="text-fabchat-subtext">Online</p>
                 </div>
             </div>
         </div>

--- a/components/home/InputMessage.tsx
+++ b/components/home/InputMessage.tsx
@@ -111,7 +111,7 @@ function InputMessage({ channelName }: { channelName: string }) {
                     <input
                         type="text"
                         className="w-4/5 outline-none rounded-lg bg-transparent px-2 py-1 text-white placeholder:text-white"
-                        placeholder={`Message @${channelName}`}
+                        placeholder={`Send Message to @${channelName}`}
                         value={message}
                         onChange={(e) => setMessage(e.target.value)}
                     />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,18 +12,19 @@ module.exports = {
     },
     extend: {
       colors: {
-        fabchat: {
+        fabchat: { //darkmint Theme
           primary: 'rgb(33, 72, 220)',
-          background: 'rgba(1, 25, 54, 1)',
-          hoverBackground: '#0A214D',
-          hoverPrimary: '#2B6CB0',
+          background: '#191E29',
+          hoverBackground: '#132D46',
+          hoverPrimary: 'rgba(1, 195, 141, 0.25)',
           hoverSecondary: '#f5f5f5',
+          addServerBtn: 'rgba(1, 195, 141, 1)' ,
           text: '#fafafa',
           white: '#ffffff',
           black: '#000000',
           inputBackground: 'linear-gradient(0deg, rgb(15, 33, 73), rgba(15, 33, 73, 1))',
           topLeft: '#2f3136',
-          subtext: 'rgba(172, 181, 199, 1)',
+          subtext: 'rgba(1, 195, 141, 1)',
         },
       },
       animation: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,19 +12,32 @@ module.exports = {
     },
     extend: {
       colors: {
-        fabchat: { //darkmint Theme
-          primary: 'rgb(33, 72, 220)',
+        fabchat: { //NEW darkmint Theme
+          primary: '#191E29',
           background: '#191E29',
           hoverBackground: '#132D46',
           hoverPrimary: 'rgba(1, 195, 141, 0.25)',
           hoverSecondary: '#f5f5f5',
-          addServerBtn: 'rgba(1, 195, 141, 1)' ,
+          addServerBtn: 'rgba(1, 195, 141, 1)' , //added color for + button
           text: '#fafafa',
           white: '#ffffff',
           black: '#000000',
           inputBackground: 'linear-gradient(0deg, rgb(15, 33, 73), rgba(15, 33, 73, 1))',
           topLeft: '#2f3136',
           subtext: 'rgba(1, 195, 141, 1)',
+        },
+        fabchatOriginal: { //Original Blue Theme
+          primary: 'rgb(33, 72, 220)',
+          background: 'rgba(1, 25, 54, 1)',
+          hoverBackground: '#0A214D',
+          hoverPrimary: '#2B6CB0',
+          hoverSecondary: '#f5f5f5',
+          text: '#fafafa',
+          white: '#ffffff',
+          black: '#000000',
+          inputBackground: 'linear-gradient(0deg, rgb(15, 33, 73), rgba(15, 33, 73, 1))',
+          topLeft: '#2f3136',
+          subtext: 'rgba(172, 181, 199, 1)',
         },
       },
       animation: {


### PR DESCRIPTION
In tailwind.config.js , the new Dark Mint theme styles are under the fabchat parent, and the original blue theme has been moved down to the parent called fabchatOriginal.

I also added styling to the "Online" status (see image 4).
Updated input message placeholder text for clarity (image 1).
<img width="1760" alt="messages-darkmint" src="https://user-images.githubusercontent.com/116777356/212503383-9095f6c2-a93c-4dce-9a4f-75e189123d7c.png">
<img width="2006" alt="home-darkmint" src="https://user-images.githubusercontent.com/116777356/212503384-13f4a9a3-88de-4e78-ac47-e53ee67c8561.png">
<img width="1925" alt="loading-darkmint" src="https://user-images.githubusercontent.com/116777356/212503386-71f2a14e-f9ce-421f-855c-e98cef852971.png">
<img width="1887" alt="channelChat-darkmint" src="https://user-images.githubusercontent.com/116777356/212503387-e4cf7043-b8f3-40c0-94bf-0a26cc07b2c5.png">
